### PR TITLE
feat: detect AI disclosure in branch name

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The built-in detectors run against each commit, each producing findings at a con
 - `aider:` prefix (Aider's default commit format).
 - `Generated with Claude Code` footer.
 - Known commit trailers in formats unique to specific tools (such as EntireIO, Replit Agent/Assistant) that can contain values indicative of AI use.
+- Branch names following conventions used by AI coding CLIs/agents (e.g. `codex/`, `claude/`, `cursor/`, `copilot/`, `devin/`, `cline/`, `aider/`, `gemini/`).
 
 
 **Low confidence** -- mentions of AI tool names in text:
@@ -104,6 +105,7 @@ import (
 	"fmt"
 
 	"github.com/chaoss/disclosure/detection"
+	"github.com/chaoss/disclosure/detection/branchname"
 	"github.com/chaoss/disclosure/detection/committer"
 	"github.com/chaoss/disclosure/detection/trailer"
 	"github.com/chaoss/disclosure/detection/toolmention"
@@ -115,6 +117,7 @@ func main() {
 		&committer.Detector{},
 		&toolmention.Detector{},
 		&trailer.Detector{},
+		&branchname.Detector{},
 	}
 
 	report, err := scan.ScanCommitRange("/path/to/repo", "base..head", detectors)
@@ -166,6 +169,7 @@ go test ./...
 
 ```
 detection/              Core types: Detector interface, Finding, Confidence, Input
+detection/branchname/   AI CLI/agent branch naming conventions (codex/, claude/, etc.)
 detection/committer/    Known AI bot committer emails
 detection/gitnotes/     git-ai authorship logs from refs/notes/ai
 detection/toolmention/  AI tool name mentions in text

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/chaoss/disclosure/detection"
+	"github.com/chaoss/disclosure/detection/branchname"
 	"github.com/chaoss/disclosure/detection/committer"
 	"github.com/chaoss/disclosure/detection/gitnotes"
 	"github.com/chaoss/disclosure/detection/toolmention"
@@ -35,6 +36,7 @@ func allDetectors() []detection.Detector {
 		&gitnotes.Detector{},
 		&trailer.Detector{},
 		&toolmention.Detector{},
+		&branchname.Detector{},
 	}
 }
 
@@ -94,6 +96,7 @@ Checks each commit for:
   - AI session ID trailers
   - Commit message patterns (aider:, Generated with Claude Code, etc.)
   - Tool name mentions in commit messages
+  - Branch naming conventions used by AI CLIs (codex/, claude/, cursor/, etc.)
 
 Examples:
   disclosure scan

--- a/detection/branchname/branchname.go
+++ b/detection/branchname/branchname.go
@@ -1,0 +1,35 @@
+// Package branchname detects AI tool involvement from branch naming conventions,
+// e.g. branches created by CLI agents such as "codex/fix-bug" or "claude/add-tests".
+package branchname
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/chaoss/disclosure/detection"
+)
+
+type Detector struct{}
+
+func (d *Detector) Name() string { return "branchname" }
+
+func (d *Detector) Detect(input detection.Input) []detection.Finding {
+	branch, err := input.GetBranchName()
+	if err != nil {
+		return nil
+	}
+
+	lower := strings.ToLower(branch)
+	for prefix, tool := range detection.KnownAgentBranchPrefixes {
+		if strings.HasPrefix(lower, prefix) {
+			return []detection.Finding{{
+				Detector:   d.Name(),
+				Tool:       tool,
+				Confidence: detection.ConfidenceMedium,
+				Detail:     fmt.Sprintf("branch name %q matches %s convention", branch, tool),
+			}}
+		}
+	}
+
+	return nil
+}

--- a/detection/branchname/branchname_test.go
+++ b/detection/branchname/branchname_test.go
@@ -1,0 +1,65 @@
+package branchname
+
+import (
+	"testing"
+
+	"github.com/chaoss/disclosure/detection"
+)
+
+func TestDetectKnownPrefixes(t *testing.T) {
+	d := &Detector{}
+	for prefix, expectedTool := range detection.KnownAgentBranchPrefixes {
+		branch := prefix + "fix-bug"
+		findings := d.Detect(detection.Input{BranchName: branch})
+		if len(findings) != 1 {
+			t.Errorf("Detect(%q): got %d findings, want 1", branch, len(findings))
+			continue
+		}
+		if findings[0].Tool != expectedTool {
+			t.Errorf("Detect(%q): tool = %q, want %q", branch, findings[0].Tool, expectedTool)
+		}
+		if findings[0].Confidence != detection.ConfidenceMedium {
+			t.Errorf("Detect(%q): confidence = %d, want %d", branch, findings[0].Confidence, detection.ConfidenceMedium)
+		}
+		if findings[0].Detector != "branchname" {
+			t.Errorf("Detect(%q): detector = %q, want %q", branch, findings[0].Detector, "branchname")
+		}
+	}
+}
+
+func TestDetectCaseInsensitive(t *testing.T) {
+	d := &Detector{}
+	findings := d.Detect(detection.Input{BranchName: "Codex/Fix-Bug"})
+	if len(findings) != 1 {
+		t.Fatalf("Detect: got %d findings, want 1", len(findings))
+	}
+	if findings[0].Tool != "OpenAI Codex" {
+		t.Errorf("Detect: tool = %q, want %q", findings[0].Tool, "OpenAI Codex")
+	}
+}
+
+func TestDetectNoMatch(t *testing.T) {
+	d := &Detector{}
+	cases := []string{
+		"main",
+		"feature/add-login",
+		"fix-codex-typo", // "codex" appears, but not as a branch prefix
+		"",
+	}
+
+	for _, branch := range cases {
+		findings := d.Detect(detection.Input{BranchName: branch})
+		if len(findings) != 0 {
+			t.Errorf("Detect(%q): got %d findings, want 0", branch, len(findings))
+		}
+	}
+}
+
+func TestDetectPrefixMustBeFollowedBySeparator(t *testing.T) {
+	// "codexterity" starts with "codex" but not "codex/" and should not match.
+	d := &Detector{}
+	findings := d.Detect(detection.Input{BranchName: "codexterity-branch"})
+	if len(findings) != 0 {
+		t.Errorf("Detect: got %d findings, want 0", len(findings))
+	}
+}

--- a/detection/constants.go
+++ b/detection/constants.go
@@ -130,6 +130,19 @@ var SupportedToolsInMentions = []string{
 	"CodeWhisperer",
 }
 
+// KnownAgentBranchPrefixes maps branch name prefixes used by AI coding CLIs/agents
+// when they create their own branches (e.g. "codex/fix-bug") to tool names.
+var KnownAgentBranchPrefixes = map[string]string{
+	"codex/":   "OpenAI Codex",
+	"claude/":  "Claude",
+	"copilot/": "GitHub Copilot",
+	"cursor/":  "Cursor",
+	"devin/":   "Devin",
+	"cline/":   "Cline",
+	"aider/":   "Aider",
+	"gemini/":  "Gemini",
+}
+
 // KnownCoAuthorEmails Known emails present with Co-Authored-By trailers
 var KnownCoAuthorEmails = map[string]string{
 	"noreply@anthropic.com":  "Claude Code",

--- a/detection/detection.go
+++ b/detection/detection.go
@@ -70,6 +70,11 @@ type Input struct {
 	Notes         string // Content from refs/notes/ai, if any
 	Text          string // For text-only scans (PR body, comments)
 	RepoPath      string
+	BranchName    string // Name of the branch the commit/PR is on, if known.
+}
+
+func (input *Input) GetBranchName() (string, error) {
+	return getCommitField(input.BranchName, fieldBranchName)
 }
 
 func (input *Input) GetAuthorEmail() (string, error) {

--- a/detection/parsing.go
+++ b/detection/parsing.go
@@ -30,6 +30,7 @@ var (
 	fieldAuthorEmail   = "author_email"
 	fieldCommitEmail   = "commit_email"
 	fieldCommitMessage = "commit_message"
+	fieldBranchName    = "branch_name"
 )
 
 func getCommitField(value string, field string) (string, error) {
@@ -44,6 +45,9 @@ func getCommitField(value string, field string) (string, error) {
 		return strings.ToLower(value), nil
 
 	case fieldCommitMessage:
+		return value, nil
+
+	case fieldBranchName:
 		return value, nil
 
 	default:

--- a/gitops/gitops.go
+++ b/gitops/gitops.go
@@ -80,6 +80,27 @@ func ListCommits(repoPath string, commitRange string) ([]Commit, error) {
 	return listCommitRange(repo, baseHash, headHash)
 }
 
+// GetCurrentBranch returns the short name of the branch currently checked out
+// in the repository at repoPath (e.g. "codex/fix-bug"). Returns an empty
+// string, with no error, when HEAD is detached (not pointing at a branch).
+func GetCurrentBranch(repoPath string) (string, error) {
+	repo, err := git.PlainOpen(repoPath)
+	if err != nil {
+		return "", fmt.Errorf("opening repo: %w", err)
+	}
+
+	head, err := repo.Reference(plumbing.HEAD, false)
+	if err != nil {
+		return "", fmt.Errorf("reading HEAD: %w", err)
+	}
+
+	if head.Type() != plumbing.SymbolicReference {
+		return "", nil
+	}
+
+	return head.Target().Short(), nil
+}
+
 func resolveRef(repo *git.Repository, name string) (plumbing.Hash, error) {
 	// Try as a full hash first
 	if plumbing.IsHash(name) {

--- a/gitops/gitops_test.go
+++ b/gitops/gitops_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 )
 
@@ -135,6 +136,66 @@ func TestListCommitsInvalidRange(t *testing.T) {
 
 func TestListCommitsInvalidRepo(t *testing.T) {
 	_, err := ListCommits(t.TempDir(), "")
+	if err == nil {
+		t.Error("expected error for non-repo directory")
+	}
+}
+
+func TestGetCurrentBranch(t *testing.T) {
+	dir, _ := initTestRepo(t)
+
+	repo, err := git.PlainOpen(dir)
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("worktree: %v", err)
+	}
+	if err := wt.Checkout(&git.CheckoutOptions{
+		Branch: "refs/heads/codex/fix-bug",
+		Create: true,
+	}); err != nil {
+		t.Fatalf("checkout: %v", err)
+	}
+
+	branch, err := GetCurrentBranch(dir)
+	if err != nil {
+		t.Fatalf("GetCurrentBranch: unexpected error: %v", err)
+	}
+	if branch != "codex/fix-bug" {
+		t.Errorf("GetCurrentBranch: got %q, want %q", branch, "codex/fix-bug")
+	}
+}
+
+func TestGetCurrentBranchDetachedHead(t *testing.T) {
+	dir, hashes := initTestRepo(t)
+
+	repo, err := git.PlainOpen(dir)
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("worktree: %v", err)
+	}
+	if err := wt.Checkout(&git.CheckoutOptions{
+		Hash: plumbing.NewHash(hashes[0]),
+	}); err != nil {
+		t.Fatalf("checkout: %v", err)
+	}
+
+	branch, err := GetCurrentBranch(dir)
+	if err != nil {
+		t.Fatalf("GetCurrentBranch: unexpected error: %v", err)
+	}
+	if branch != "" {
+		t.Errorf("GetCurrentBranch: got %q, want empty string for detached HEAD", branch)
+	}
+}
+
+func TestGetCurrentBranchInvalidRepo(t *testing.T) {
+	_, err := GetCurrentBranch(t.TempDir())
 	if err == nil {
 		t.Error("expected error for non-repo directory")
 	}

--- a/scan/scan.go
+++ b/scan/scan.go
@@ -32,9 +32,13 @@ func ScanCommitRange(repoPath, commitRange string, detectors []detection.Detecto
 		return Report{}, err
 	}
 
+	// Best-effort: an empty branch name (e.g. detached HEAD, common in CI
+	// checkouts) simply means the branchname detector finds nothing.
+	branchName, _ := gitops.GetCurrentBranch(repoPath)
+
 	var results []CommitResult
 	for _, c := range commits {
-		result := scanOneCommit(c, detectors)
+		result := scanOneCommit(c, branchName, detectors)
 		results = append(results, result)
 	}
 
@@ -48,7 +52,8 @@ func ScanCommit(repoPath, hash string, detectors []detection.Detector) (CommitRe
 		return CommitResult{}, err
 	}
 
-	return scanOneCommit(c, detectors), nil
+	branchName, _ := gitops.GetCurrentBranch(repoPath)
+	return scanOneCommit(c, branchName, detectors), nil
 }
 
 // ScanText runs detectors against arbitrary text (PR body, comments, etc).
@@ -61,13 +66,14 @@ func ScanText(text string, detectors []detection.Detector) []detection.Finding {
 	return findings
 }
 
-func scanOneCommit(c gitops.Commit, detectors []detection.Detector) CommitResult {
+func scanOneCommit(c gitops.Commit, branchName string, detectors []detection.Detector) CommitResult {
 	input := detection.Input{
 		CommitHash:    c.Hash,
 		AuthorEmail:   c.AuthorEmail,
 		CommitEmail:   c.CommitterEmail,
 		CommitMessage: c.Message,
 		Notes:         c.Notes,
+		BranchName:    branchName,
 	}
 
 	var findings []detection.Finding


### PR DESCRIPTION
**Description**
Adds a `branchname` detector that flags branches created by AI coding CLIs/agents using their conventional prefixes (`codex/`, `claude/`, `cursor/`, `copilot/`, `devin/`, `cline/`, `aider/`, `gemini/`), matching the pattern noticed in chaoss/CollectOSS#397.

- New `detection.Input.BranchName` field + `GetBranchName()` accessor
- New `gitops.GetCurrentBranch(repoPath)` resolving the checked-out branch once per scan (empty string, no error, on detached HEAD)
- New `detection/branchname` detector, registered alongside the existing detectors
- Confidence: medium (naming convention, not proof, same tier as commit-message pattern matches)

This PR fixes #50

**Notes for Reviewers**
- Verified locally: a repo with a commit on a `codex/fix-typo` branch is flagged (medium confidence), a normal `feature/...` branch is not.
- `go test ./...` and `go vet ./...` pass.
- Prefix list mirrors the tool names already used by the `committer` detector; happy to extend/adjust the prefix map if there are other conventions to cover.

**Signed commits**
- [x] Yes, I signed my commits.

**Generative AI disclosure**

Please select one option:

- [ ] This contribution was NOT assisted or created by Generative AI tools.
- [x] This contribution was assisted or created by Generative AI tools.

If AI tools were used, please provide details below:
- What tools were used? Claude (Claude Code)
- How were these tools used? I asked Claude Code to find a good-first-issue in an active open-source project, and it picked this issue, read the existing detectors to follow the codebase's conventions, wrote the implementation (detector, gitops helper, wiring) and the tests, and drafted this PR description.
- Did you review these outputs before submitting this PR? Yes: I watched it reproduce the current behavior first, reviewed the diff, and confirmed locally that `go test ./...` passes and that the CLI correctly flags a `codex/*` branch while leaving a normal branch untouched before opening this PR.
