### PR TITLE
feat(action): add PR re-titling option when AI is detected (#84)

### DIFF
--- a/action/action.yml
+++ b/action/action.yml
@@ -37,6 +37,14 @@ inputs:
     description: 'Label for checkbox in PR description for user to declare that AI was not used'
     required: false
     default: 'This contribution was NOT assisted or created by Generative AI tools.'
+  retitling-enabled:
+    description: 'Enable/disable re-titling the PR/issue when AI is detected'
+    required: false
+    default: 'false'
+  title-prefix:
+    description: 'Prefix to prepend to the PR/issue title when AI is detected (e.g. "[AI Detected] ")'
+    required: false
+    default: '[AI Detected] '
 
 outputs:
   ai-detected:
@@ -130,3 +138,17 @@ runs:
 
         # Apply the label to the PR
         gh pr edit "${PR_NUMBER}" --add-label "${LABEL}"
+
+    - name: Re-title PR/issue
+      if: steps.scan.outputs.ai-detected == 'true' && inputs.retitling-enabled == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        TITLE_PREFIX: ${{ inputs.title-prefix }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        CURRENT_TITLE: ${{ github.event.pull_request.title }}
+      run: |
+        # Prepend prefix if not already present
+        if [[ "${CURRENT_TITLE}" != "${TITLE_PREFIX}"* ]]; then
+          gh pr edit "${PR_NUMBER}" --title "${TITLE_PREFIX}${CURRENT_TITLE}"
+        fi


### PR DESCRIPTION
Description

Adds retitling-enabled and title-prefix inputs so communities with a no-AI policy can automatically add a configurable prefix, such as [AI Detected] , to a PR title when AI involvement is detected. The step also prevents double-prefixing by checking whether the current title already starts with the configured prefix before updating it. This requires pull-requests: write permission when enabled.

This PR fixes #84

Notes for Reviewers
Signed commits
[x] Yes, I signed my commits.
Generative AI disclosure
<!-- To learn more about our Generative AI policy and required disclosures, see the `CONTRIBUTING.md` file -->

Please select one option:


- [x] This contribution was NOT assisted or created by Generative AI tools.
- [ ] This contribution was assisted or created by Generative AI tools.

If AI tools were used, please provide details below:

What tools were used? <!-- Gemini / ChatGPT / Claude, etc. -->
How were these tools used? <!-- Initial draft of the code / code review / writing tests, etc. -->
Did you review these outputs before submitting this PR? <!-- No / Yes, and I made these fixes... -->