### PR TITLE
feat(detection): support CodiumAI PR-Agent committer emails (#96)

### DIFF
--- a/detection/committer/committer_test.go
+++ b/detection/committer/committer_test.go
@@ -59,6 +59,7 @@ func TestDetectMixedCase(t *testing.T) {
 		{"198982749+Copilot@users.noreply.github.com", "GitHub Copilot (agent)"},
 		{"209825114+CLAUDE[BOT]@USERS.NOREPLY.GITHUB.COM", "Claude"},
 		{"136622811+CodeRabbitAI[bot]@users.noreply.github.com", "CodeRabbit"},
+		{"151058649+codiumai-pr-agent-pro[bot]@users.noreply.github.com", "PR-Agent Pro"},
 	}
 
 	for _, tc := range cases {
@@ -126,6 +127,10 @@ func TestDetectNumericPrefix(t *testing.T) {
 		{"198982749+copilot-v2@users.noreply.github.com", "GitHub Copilot (agent)"},
 		// CodeRabbit with a different username
 		{"136622811+coderabbit-new@users.noreply.github.com", "CodeRabbit"},
+		// PR-Agent Pro with a different username
+		{"151058649+pr-agent-pro-renamed@users.noreply.github.com", "PR-Agent Pro"},
+		// PR-Agent Pro rebranded username
+		{"151058649+qodo-code-review[bot]@users.noreply.github.com", "PR-Agent Pro"},
 	}
 
 	for _, tc := range cases {
@@ -161,6 +166,7 @@ func TestDetectAuthorAndCommitter(t *testing.T) {
 	const (
 		claudeEmail  = "209825114+claude[bot]@users.noreply.github.com"
 		copilotEmail = "198982749+copilot@users.noreply.github.com"
+		prAgentEmail = "151058649+codiumai-pr-agent-pro[bot]@users.noreply.github.com"
 		humanEmail   = "human@example.com"
 	)
 
@@ -191,6 +197,27 @@ func TestDetectAuthorAndCommitter(t *testing.T) {
 			wantTools: []string{detection.KnownAgentCommitters[claudeEmail]},
 			wantDetails: []string{
 				"committer email " + claudeEmail + " matches known AI bot",
+			},
+		},
+		{
+			name: "committer only with PR-Agent Pro in the wild",
+			input: detection.Input{
+				AuthorEmail: humanEmail,
+				CommitEmail: prAgentEmail,
+			},
+			wantTools: []string{detection.KnownAgentCommitters[prAgentEmail]},
+			wantDetails: []string{
+				"committer email " + prAgentEmail + " matches known AI bot",
+			},
+		},
+		{
+			name: "committer in the wild without author",
+			input: detection.Input{
+				CommitEmail: prAgentEmail,
+			},
+			wantTools: []string{detection.KnownAgentCommitters[prAgentEmail]},
+			wantDetails: []string{
+				"committer email " + prAgentEmail + " matches known AI bot",
 			},
 		},
 		{

--- a/detection/constants.go
+++ b/detection/constants.go
@@ -21,6 +21,7 @@ var KnownAgentCommitters = map[string]string{
 	"201248094+sourcegraph-cody[bot]@users.noreply.github.com":        "Sourcegraph Cody",
 	"220155983+jetbrains-ai[bot]@users.noreply.github.com":            "JetBrains AI",
 	"136622811+coderabbitai[bot]@users.noreply.github.com":            "CodeRabbit",
+	"151058649+codiumai-pr-agent-pro[bot]@users.noreply.github.com":    "PR-Agent Pro",
 }
 
 // GithubNoReplyEmailSuffix GitHub noreply emails suffix to check committer emails.

--- a/detection/trailer/trailer_test.go
+++ b/detection/trailer/trailer_test.go
@@ -145,6 +145,30 @@ Co-authored-by: Copilot Autofix powered by AI <175728472+Copilot@users.noreply.g
 			wantConfidence: []detection.Confidence{detection.ConfidenceHigh},
 		},
 		{
+			name: "coauthor: PR-Agent Pro in the wild should have high confidence",
+			message: `
+[dotnet] Don't include http headers in internal logs (#14546)
+
+* [dotnet] Don't include http headers in internal logs
+
+* Update dotnet/src/webdriver/Remote/HttpCommandExecutor.cs
+
+Co-authored-by: codiumai-pr-agent-pro[bot] <151058649+codiumai-pr-agent-pro[bot]@users.noreply.github.com>
+
+* Update dotnet/src/webdriver/Remote/HttpCommandExecutor.cs
+
+Co-authored-by: codiumai-pr-agent-pro[bot] <151058649+codiumai-pr-agent-pro[bot]@users.noreply.github.com>
+
+---------
+
+Co-authored-by: codiumai-pr-agent-pro[bot] <151058649+codiumai-pr-agent-pro[bot]@users.noreply.github.com>
+`,
+			wantTools:      []string{"PR-Agent Pro"},
+			wantModels:     []string{""},
+			wantScore:      []float64{75},
+			wantConfidence: []detection.Confidence{detection.ConfidenceHigh},
+		},
+		{
 			name:           "coauthor: human co-author only",
 			message:        "pair programming\n\nCo-Authored-By: Bob <bob@company.com>",
 			wantTools:      nil,


### PR DESCRIPTION
**Description**
- Adds known committer email mapping for CodiumAI PR-Agent bots to `KnownAgentCommitters`:
  - `151058649+codiumai-pr-agent-pro[bot]@users.noreply.github.com` (PR-Agent Pro)
- Adds corresponding unit tests in `committer_test.go` to cover mixed case, rename simulations, and direct matching.

This PR fixes #96

**Notes for Reviewers**
- The committer detector automatically parses the numeric prefixes for GitHub noreply emails (`151058649`), so this ensures reliable detection even if the bot's username changes (e.g. its rebranding to `qodo-code-review[bot]`).
- Real-world in-the-wild commit example: [SeleniumHQ/selenium commit `0cd8bbc268c3`](https://github.com/SeleniumHQ/selenium/commit/0cd8bbc268c3735bdbe67f9f738c845514be55ff) from [Selenium PR #14546](https://github.com/SeleniumHQ/selenium/pull/14546).
- The non-pro ID `139055413` was removed as it belongs to an individual user account rather than a bot and had no in-the-wild commits.

**Signed commits**
- [x] Yes, I signed my commits.


**Generative AI disclosure**
<!-- To learn more about our Generative AI policy and required disclosures, see the `CONTRIBUTING.md` file -->

Please select one option:

- [x] This contribution was NOT assisted or created by Generative AI tools.
- [ ] This contribution was assisted or created by Generative AI tools.


If AI tools were used, please provide details below:
    - What tools were used? <!-- gemini / chatgpt / claude .etc -->
    - How were these tools used? <!-- initial draft of the code / code review / writing tests .etc -->
    - Did you review these outputs before submitting this PR? <!-- No / Yes and I made these fixes... -->