### PR TITLE
Include agent committer emails in trailer detector

### DIFF
--- a/detection/constants.go
+++ b/detection/constants.go
@@ -7,6 +7,7 @@ var KnownAgentCommitters = map[string]string{
 	"209825114+claude[bot]@users.noreply.github.com":                  "Claude",
 	"215619710+anthropic-claude[bot]@users.noreply.github.com":        "Claude (Anthropic)",
 	"208546643+claude-code-action[bot]@users.noreply.github.com":      "Claude Code Action",
+	"175728472+copilot@users.noreply.github.com":                      "GitHub Copilot",
 	"198982749+copilot@users.noreply.github.com":                      "GitHub Copilot (agent)",
 	"167198135+copilot[bot]@users.noreply.github.com":                 "GitHub Copilot (chat)",
 	"206951365+cursor[bot]@users.noreply.github.com":                  "Cursor",
@@ -20,7 +21,6 @@ var KnownAgentCommitters = map[string]string{
 	"201248094+sourcegraph-cody[bot]@users.noreply.github.com":        "Sourcegraph Cody",
 	"220155983+jetbrains-ai[bot]@users.noreply.github.com":            "JetBrains AI",
 	"136622811+coderabbitai[bot]@users.noreply.github.com":            "CodeRabbit",
-	"175728472+copilot@users.noreply.github.com":                      "GitHub Copilot",
 }
 
 // GithubNoReplyEmailSuffix GitHub noreply emails suffix to check committer emails.

--- a/detection/constants.go
+++ b/detection/constants.go
@@ -20,6 +20,7 @@ var KnownAgentCommitters = map[string]string{
 	"201248094+sourcegraph-cody[bot]@users.noreply.github.com":        "Sourcegraph Cody",
 	"220155983+jetbrains-ai[bot]@users.noreply.github.com":            "JetBrains AI",
 	"136622811+coderabbitai[bot]@users.noreply.github.com":            "CodeRabbit",
+	"175728472+copilot@users.noreply.github.com":                      "GitHub Copilot",
 }
 
 // GithubNoReplyEmailSuffix GitHub noreply emails suffix to check committer emails.

--- a/detection/trailer/trailer.go
+++ b/detection/trailer/trailer.go
@@ -152,6 +152,22 @@ func extractCoauthorModel(tool, namePart string) string {
 	return ""
 }
 
+func getAgentName(email string) (string, bool) {
+	var name string
+	var ok bool
+
+	name, ok = detection.KnownCoAuthorEmails[email]
+	if ok {
+		return name, ok
+	}
+	name, ok = detection.KnownAgentCommitters[email]
+	if ok {
+		return name, ok
+	}
+
+	return "", false
+}
+
 func (d *Detector) detectTrailerCoauthoredBy(commitMessage string) []detection.Finding {
 	var findings []detection.Finding
 
@@ -170,7 +186,7 @@ func (d *Detector) detectTrailerCoauthoredBy(commitMessage string) []detection.F
 		email := strings.ToLower(strings.TrimSpace(match[2]))
 		score := detection.CoauthoredByTrailerBaseScore
 
-		if name, ok := detection.KnownCoAuthorEmails[email]; ok {
+		if name, ok := getAgentName(email); ok {
 			model := extractCoauthorModel(name, namePart)
 			if model != "" {
 				score += detection.CoauthorModelBonusPoints

--- a/detection/trailer/trailer_test.go
+++ b/detection/trailer/trailer_test.go
@@ -130,6 +130,21 @@ func TestDetect(t *testing.T) {
 			wantConfidence: []detection.Confidence{detection.ConfidenceHigh},
 		},
 		{
+			name: "coauthor: Co-Authored-By in the wild should have high confidence",
+			message: `
+fix: remove references to "bot"
+We dropped the "bot" from our terminology long ago, but it looks like
+we've got some outdated docs + code that reference it.
+
+Co-authored-by: Claude Sonnet 5 <john.doe+claude-code@example.com>
+Co-authored-by: Copilot Autofix powered by AI <175728472+Copilot@users.noreply.github.com>
+`,
+			wantTools:      []string{"GitHub Copilot"},
+			wantModels:     []string{""},
+			wantScore:      []float64{75},
+			wantConfidence: []detection.Confidence{detection.ConfidenceHigh},
+		},
+		{
 			name:           "coauthor: human co-author only",
 			message:        "pair programming\n\nCo-Authored-By: Bob <bob@company.com>",
 			wantTools:      nil,


### PR DESCRIPTION
**Description**
This PR fixes #101.

**Notes for Reviewers**
- This includes KnownCommitterEmails in the trailer detector, for more effective Co-Authored-by detection. See [this change](https://github.com/chaoss/disclosure/pull/103/changes#diff-bab7a3b0cbf66d47887042d837134fdb6b8c5765612c6153da6ddbea6d055da3R155-R170) for more info.
- This also adds the in-the-wild email address `175728472+Copilot@users.noreply.github.com` to the KnownCommitterEmails list, as it's used by Copilot for agentic and autofix workflows. See [this change](https://github.com/chaoss/disclosure/pull/103/changes#diff-4011e4732b93ff2ee4d8700ba7a6c14f2f60f90975f7296a09ee07976d7b8a65R23).
- Also adds failing test based on the [issue's description](https://github.com/chaoss/disclosure/issues/101#issue-5327473735).

**Signed commits**
- [x] Yes, I signed my commits.

**Generative AI disclosure**
<!-- To learn more about our Generative AI policy and required disclosures, see the `CONTRIBUTING.md` file -->

Please select one option:

- [x] This contribution was NOT assisted or created by Generative AI tools.
- [ ] This contribution was assisted or created by Generative AI tools.

If AI tools were used, please provide details below:
    - What tools were used? <!-- gemini / chatgpt / claude .etc -->
    - How were these tools used? <!-- initial draft of the code / code review / writing tests .etc -->
    - Did you review these outputs before submitting this PR? <!-- No / Yes and I made these fixes... -->

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles
2. Build and test your changes before submitting a PR
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/disclosure/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->
