### PR TITLE
version: fall back to build info when not set via ldflags (#99)

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -28,9 +28,7 @@ var Version = "dev"
 
 // resolveVersion returns the CLI version to display. Release builds inject the
 // version at link time via ldflags (-X ...cmd.Version=...). When that has not
-// happened (Version is still the "dev" default) — for example a `go install
-// github.com/chaoss/disclosure@v1.2.3` build — fall back to the module version
-// recorded in the binary's build info so the reported version is accurate.
+// happened, fall back to the module version recorded in binary's build info.
 func resolveVersion() string {
 	return versionFrom(Version, readBuildVersion)
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"slices"
 	"strconv"
 	"strings"
@@ -24,6 +25,34 @@ import (
 )
 
 var Version = "dev"
+
+// resolveVersion returns the CLI version to display. Release builds inject the
+// version at link time via ldflags (-X ...cmd.Version=...). When that has not
+// happened (Version is still the "dev" default) — for example a `go install
+// github.com/chaoss/disclosure@v1.2.3` build — fall back to the module version
+// recorded in the binary's build info so the reported version is accurate.
+func resolveVersion() string {
+	return versionFrom(Version, readBuildVersion)
+}
+
+// versionFrom selects the version string, preferring an ldflags override and
+// otherwise using the build-info version. It is split out for testability.
+func versionFrom(override string, buildVersion func() string) string {
+	if override != "dev" && override != "" {
+		return override
+	}
+	if bv := buildVersion(); bv != "" && bv != "(devel)" {
+		return bv
+	}
+	return "dev"
+}
+
+func readBuildVersion() string {
+	if info, ok := debug.ReadBuildInfo(); ok {
+		return info.Main.Version
+	}
+	return ""
+}
 
 // Exit codes
 const (
@@ -376,7 +405,7 @@ Examples:
 		Example: `  disclosure version
   disclosure version --format=json`,
 		Run: func(_ *cobra.Command, _ []string) {
-			fmt.Fprintf(stdout, "disclosure %s\n", Version)
+			fmt.Fprintf(stdout, "disclosure %s\n", resolveVersion())
 			*exitCode = ExitNoAI
 		},
 	}

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,26 @@
+package cmd
+
+import "testing"
+
+func TestVersionFrom(t *testing.T) {
+	cases := []struct {
+		name     string
+		override string
+		build    string
+		want     string
+	}{
+		{"ldflags override wins", "1.2.3", "v9.9.9", "1.2.3"},
+		{"dev falls back to build info", "dev", "v1.0.1", "v1.0.1"},
+		{"empty override falls back to build info", "", "v2.0.0", "v2.0.0"},
+		{"devel build info is ignored", "dev", "(devel)", "dev"},
+		{"empty build info falls back to dev", "dev", "", "dev"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := versionFrom(c.override, func() string { return c.build })
+			if got != c.want {
+				t.Errorf("versionFrom(%q, ()=>%q) = %q, want %q", c.override, c.build, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Description**
The `version` subcommand printed the hardcoded default `dev` for any binary not built through goreleaser (which injects the version via ldflags), e.g. `go install github.com/chaoss/disclosure@v1.2.3`.

This adds `resolveVersion`: it prefers the ldflags override, otherwise uses the module version from `runtime/debug.ReadBuildInfo()` (ignoring the `(devel)` placeholder), and falls back to `dev` only when neither is available. The selection logic is split into `versionFrom` for deterministic unit tests. The existing goreleaser ldflags path and `TestRunVersion` are unaffected. `go vet ./...` and `go test ./...` pass.

This PR fixes #99

**Notes for Reviewers**

**Signed commits**
- [x] Yes, I signed my commits.


**Generative AI disclosure**
<!-- To learn more about our Generative AI policy and required disclosures, see the `CONTRIBUTING.md` file -->

Please select one option:

- [ ] This contribution was NOT assisted or created by Generative AI tools.
- [x] This contribution was assisted or created by Generative AI tools.

## Generative AI usage
- **Problem + approach:** identified by me — `version` printed the hardcoded `dev` default for non-goreleaser builds (e.g. `go install ...@vX.Y.Z`); fix keeps the ldflags override primary and falls back to build info.
- **Implementation:** written with an AI coding agent (Claude Code) — `resolveVersion`/`versionFrom` and the unit test, against the existing code.
- **Review + verification:** reviewed the diff and ran `go vet ./...` + `go test ./...` locally; confirmed the existing ldflags path and `TestRunVersion` are unchanged.