### PR TITLE
fix(gitops): resolve abbreviated range hashes (#108)

### DIFF
--- a/gitops/gitops.go
+++ b/gitops/gitops.go
@@ -1,6 +1,7 @@
 package gitops
 
 import (
+	"encoding/hex"
 	"fmt"
 	"io"
 	"strings"
@@ -121,8 +122,85 @@ func resolveRef(repo *git.Repository, name string) (plumbing.Hash, error) {
 		}
 	}
 
-	// Try as abbreviated hash by iterating objects (go-git doesn't support short hashes natively)
-	return plumbing.Hash{}, fmt.Errorf("cannot resolve %q to a commit", name)
+	// go-git does not resolve abbreviated object IDs, so match unique prefixes
+	// across all object types. Git requires at least four hexadecimal digits
+	// for an abbreviated object name.
+	const minAbbreviatedHashLength = 4
+	if len(name) < minAbbreviatedHashLength || len(name) >= len(plumbing.ZeroHash)*2 ||
+		!isHex(name) {
+		return plumbing.Hash{}, fmt.Errorf("cannot resolve %q to a commit", name)
+	}
+
+	prefix := strings.ToLower(name)
+	matches, err := hashesWithPrefix(repo, prefix)
+	if err != nil {
+		return plumbing.Hash{}, err
+	}
+	if len(matches) == 0 {
+		return plumbing.Hash{}, fmt.Errorf("cannot resolve %q to a commit", name)
+	}
+	if len(matches) > 1 {
+		return plumbing.Hash{}, fmt.Errorf("ambiguous abbreviated hash %q", name)
+	}
+
+	return matches[0], nil
+}
+
+func hashesWithPrefix(repo *git.Repository, prefix string) ([]plumbing.Hash, error) {
+	// Filesystem storage has an indexed prefix lookup that handles both loose
+	// and packed objects. Keep an iterator fallback for other storage backends.
+	type prefixStorer interface {
+		HashesWithPrefix([]byte) ([]plumbing.Hash, error)
+	}
+
+	evenHex := prefix[:len(prefix)&^1]
+	prefixBytes, err := hex.DecodeString(evenHex)
+	if err != nil {
+		return nil, fmt.Errorf("decoding abbreviated hash %q: %w", prefix, err)
+	}
+
+	if storer, ok := repo.Storer.(prefixStorer); ok {
+		candidates, err := storer.HashesWithPrefix(prefixBytes)
+		if err != nil {
+			return nil, fmt.Errorf("resolving abbreviated hash %q: %w", prefix, err)
+		}
+		matches := candidates[:0]
+		for _, hash := range candidates {
+			if strings.HasPrefix(hash.String(), prefix) {
+				matches = append(matches, hash)
+			}
+		}
+		return matches, nil
+	}
+
+	iter, err := repo.Storer.IterEncodedObjects(plumbing.AnyObject)
+	if err != nil {
+		return nil, fmt.Errorf("iterating objects: %w", err)
+	}
+
+	var matches []plumbing.Hash
+	err = iter.ForEach(func(obj plumbing.EncodedObject) error {
+		hash := obj.Hash()
+		if strings.HasPrefix(hash.String(), prefix) {
+			matches = append(matches, hash)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("iterating objects: %w", err)
+	}
+	return matches, nil
+}
+
+func isHex(s string) bool {
+	for _, r := range s {
+		if !('0' <= r && r <= '9') &&
+			!('a' <= r && r <= 'f') &&
+			!('A' <= r && r <= 'F') {
+			return false
+		}
+	}
+	return true
 }
 
 func listAllCommits(repo *git.Repository) ([]Commit, error) {

--- a/gitops/gitops_test.go
+++ b/gitops/gitops_test.go
@@ -3,6 +3,7 @@ package gitops
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -122,6 +123,92 @@ func TestListCommitsRange(t *testing.T) {
 	}
 	if commitHashes[hashes[0]] {
 		t.Error("base commit should be excluded from range")
+	}
+}
+
+func TestListCommitsRangeAbbreviatedHashes(t *testing.T) {
+	dir, hashes := initTestRepo(t)
+
+	commits, err := ListCommits(dir, hashes[0][:7]+".."+hashes[2][:7])
+	if err != nil {
+		t.Fatalf("ListCommits: %v", err)
+	}
+
+	if len(commits) != 2 {
+		t.Fatalf("got %d commits, want 2", len(commits))
+	}
+}
+
+func TestResolveRefAbbreviatedHash(t *testing.T) {
+	dir, hashes := initTestRepo(t)
+	repo, err := git.PlainOpen(dir)
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+
+	for _, name := range []string{
+		hashes[1][:8],
+		hashes[1][:7],
+		strings.ToUpper(hashes[1][:7]),
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := resolveRef(repo, name)
+			if err != nil {
+				t.Fatalf("resolveRef(%q): %v", name, err)
+			}
+			if got.String() != hashes[1] {
+				t.Fatalf("resolveRef(%q) = %s, want %s", name, got, hashes[1])
+			}
+		})
+	}
+}
+
+func TestResolveRefRejectsAmbiguousAbbreviatedHash(t *testing.T) {
+	dir, _ := initTestRepo(t)
+	repo, err := git.PlainOpen(dir)
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+
+	// These blob contents have distinct hashes sharing the prefix b285.
+	for _, content := range []string{"collision candidate 235", "collision candidate 319"} {
+		obj := &plumbing.MemoryObject{}
+		obj.SetType(plumbing.BlobObject)
+		writer, err := obj.Writer()
+		if err != nil {
+			t.Fatalf("object writer: %v", err)
+		}
+		if _, err := writer.Write([]byte(content)); err != nil {
+			t.Fatalf("write object: %v", err)
+		}
+		if err := writer.Close(); err != nil {
+			t.Fatalf("close object: %v", err)
+		}
+		if _, err := repo.Storer.SetEncodedObject(obj); err != nil {
+			t.Fatalf("store object: %v", err)
+		}
+	}
+
+	_, err = resolveRef(repo, "b285")
+	if err == nil || !strings.Contains(err.Error(), "ambiguous abbreviated hash") {
+		t.Fatalf("resolveRef() error = %v, want ambiguity error", err)
+	}
+}
+
+func TestResolveRefRejectsInvalidAbbreviatedHashes(t *testing.T) {
+	dir, _ := initTestRepo(t)
+	repo, err := git.PlainOpen(dir)
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+
+	for _, name := range []string{"abc", "not-a-hash", "deadbeef"} {
+		t.Run(name, func(t *testing.T) {
+			_, err := resolveRef(repo, name)
+			if err == nil || !strings.Contains(err.Error(), "cannot resolve") {
+				t.Fatalf("resolveRef(%q) error = %v, want resolution error", name, err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
**Description**

`disclosure scan --range` documents abbreviated hashes such as `abc123..def456`, but `resolveRef` previously accepted only full hashes and named refs.

This adds collision-safe abbreviated object resolution:

- Require at least four hexadecimal characters, matching Git's minimum abbreviation length.
- Match across all Git object types so a commit prefix that collides with another object is not treated as unique.
- Use go-git's indexed `HashesWithPrefix` lookup for filesystem storage, with an object-iterator fallback for other storage backends.
- Reject ambiguous prefixes explicitly and preserve the existing behavior for full hashes and refs.
- Cover abbreviated base/head range resolution, ambiguity across stored objects, too-short/non-hex input, and nonexistent prefixes.

This PR fixes #108.

**Notes for Reviewers**

Reproduction against this repository now gets past range resolution with `90877f4..24c489f`; before this change it exited with `cannot resolve "90877f4" to a commit`.

Validation:

- `go test ./...`
- `go vet ./...`
- `git diff --check`

**Signed commits**
- [x] Yes, I signed my commits.

**Generative AI disclosure**

- [ ] This contribution was NOT assisted or created by Generative AI tools.
- [x] This contribution was assisted or created by Generative AI tools.

AI tools used: OpenAI Codex.

I identified the documented-command mismatch and approved the collision-safe behavior. Codex helped inspect go-git's storage APIs, draft the implementation and regression tests, and run verification. I reviewed the complete diff, simplified the initial two-pass resolver, checked the indexed/fallback behavior, and personally verified the original abbreviated range command against this repository. I understand and stand behind the submitted code.
